### PR TITLE
Fix Missing CSS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,37 +4,37 @@ inc:
   subtitle:     "Indonesian Ruby Community"
   cover_image:  blog-cover.JPG
   logo:         logo.png
-  
+
   # Company information
   company:      Ruby ID
   url:          http://ruby.id/
-  
+
   # Product Information
   product_link: "https://docs.google.com/forms/d/e/1FAIpQLScsqNIz6VOYzOPukfN9X9saS-PwgN16_d1N3N5vIKgIUgJj5A/viewform"
   tagline:      "RubyConf 2017"
-  
+
   # Comments
   disqus:
     # Eg. "exampleblog" Set to false to disable comments
     shortname:  false
-  
+
   # Sharing settings
   sharing:
     twitter:    false
     facebook:   false
     gplus:      false
     hn:         false
-    
-  
- # Analytics     
+
+
+ # Analytics
   analytics:
     google: false # Add tracking code in _includes/_google-analytics.html
-      
-      
+
+
   # Google Fonts
   # eg. 'Droid+Sans:400,700|Droid+Serif:400,700'
   # google_font: 'Droid+Sans:400,700'
-  
+
   # Setup your fonts, colors etc at _assets/stylesheets/main.scss
 
 url:         http://ruby.id
@@ -105,7 +105,8 @@ redcloth:
 # jekyll-assets: see more at https://github.com/ixti/jekyll-assets
 #
 assets:
-
+  assets:
+    - main.css
   dirname: assets
   baseurl: /assets/
   sources:


### PR DESCRIPTION
Second time I ran `bin/jekyll s`, the CSS is not generated. This should fix it:

### Before:

<img width="704" alt="screen shot 2017-02-07 at 2 45 34 pm" src="https://cloud.githubusercontent.com/assets/157515/22682334/b7b3eb7a-ed44-11e6-9de3-b649915c0104.png">

### After:

<img width="704" alt="screen shot 2017-02-07 at 2 46 11 pm" src="https://cloud.githubusercontent.com/assets/157515/22682333/b7b30b56-ed44-11e6-9a47-5b8032eab07a.png">