### PR TITLE
Convert HTML to proper Jekyll's _data

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Untuk menjalankan sistem di local:
 ## Langkah penambahan logo perusahaan/startup
 
 1. Tambahkan file logo anda di folder `images` dengan format `logo_{nama_entitas}.png`.
-2. Buka file `_includes/_companies.html`.
+2. Buka file `_data/companies.yml`.
 3. Tambahkan entitas anda sesuai urutan abjad.
 4. Tambahkan deskripsi sesingkat mungkin, berikut penjelasan singkat bagaimana Ruby digunakan di perusahaan/startup/organisasi anda.
 5. Buat pull request

--- a/_data/companies.yml
+++ b/_data/companies.yml
@@ -1,0 +1,84 @@
+- name: Alodokter.com
+  url: http://www.alodokter.com
+  image_url: images/logo_alodokter.png
+  description: Alodokter.com adalah situs kesehatan No. 1 di Indonesia yang menggunakan Ruby sebagai back-end untuk App dan Web.
+
+- name: Bukalapak
+  url: http://bukalapak.com
+  image_url: images/logo_bukalapak.png
+  description: The biggest e-commerce marketplace in Indonesia.
+
+- name: Cookpad Indonesia
+  url: https://cookpad.com/id
+  image_url: images/logo_cookpad.png
+  description: Perusahaan teknologi global dengan misi membuat masak sehari-hari jadi menyenangkan.
+
+- name: CPXi
+  url: http://cpxi-asia.com/
+  image_url: images/logo_cpxi.png
+  description: CPXi is a growing, global digital media company which includes media executions, content creation, dan engagement strategies.
+
+- name: Forstok
+  url: https://www.forstok.com/
+  image_url: images/logo_forstok.png
+  description: FORSTOK is an operating system for multi-channel retail business. It automatically synchronizes inventory, orders, customers and financial data across channels.
+
+- name: GO-JEK
+  url: https://www.go-jek.com
+  image_url: images/logo_gojek.png
+  description: GO-JEK adalah sebuah perusahaan teknologi berjiwa sosial yang bertujuan untuk meningkatkan kesejahteraan pekerja di berbagai sektor informal di Indonesia.
+
+- name: HIJUP
+  url: https://www.hijup.com/
+  image_url: images/logo_hijup.png
+  description: Modest Fashion Online
+
+- name: Jualo
+  url: https://www.jualo.com
+  image_url: images/logo_jualo.png
+  description: Jualo is Indonesia's fastest growing and best-in-class eclassifieds marketplace
+
+- name: Midtrans
+  url: http://midtrans.com
+  image_url: images/logo_midtrans.png
+  description: Melengkapi bisnis online di Indonesia dengan sistem pembayaran yang aman & nyaman
+
+- name: Peentar
+  url: http://peentar.com
+  image_url: images/logo_peentar.png
+  description: Platform Software-as-a-service untuk enterprise dengan fokus pada perangkat-perangkat IoT
+
+- name: Quipper
+  url: https://school.quipper.com/id/
+  image_url: images/logo_quipper.png
+  description: Creating a learning revolution with technology
+
+- name: Sejasa
+  url: http://www.sejasa.com
+  image_url: images/logo_sejasa.png
+  description: Sejasa is a service marketplace to find trusted and recommended service providers in Indonesia.
+
+- name: Sribulancer
+  url: https://www.sribulancer.com/
+  image_url: images/logo_sribulancer.png
+  description: Sribulancer membantu bisnis dan konsumer untuk mencari freelancer bertalenta di seluru dunia.
+
+- name: Starqle
+  url: http://starqle.com
+  image_url: images/logo_starqle.png
+  description: Software consulting company specialized in delivering large scale information systems and applications.
+
+- name: Virkea
+  url: http://virkea.com
+  image_url: images/logo_virkea.png
+  description: Enterprise-grade E-Procurement solution provider.
+
+- name: Wego
+  url: https://www.wego.co.id
+  image_url: images/logo_wego.jpg
+  description: Wego is a travel search engine. It operates 52 country sites (CcTLD) in over 20 languages and local currencies.
+
+- name: WGS
+  url: https://wgs.co.id/
+  image_url: images/logo_wgs.png
+  description: One of the largest IT service company offering programming outsourcing, personalized business and enterprise solutions.

--- a/_includes/_companies.html
+++ b/_includes/_companies.html
@@ -1,142 +1,16 @@
 <section id="box">
-   <h2>Pengguna Ruby</h2>
-   <p>Startup/Perusahaan pengguna Ruby dan Rails di Indonesia</p>
+  <h2>Pengguna Ruby</h2>
+  <p>Startup/Perusahaan pengguna Ruby dan Rails di Indonesia</p>
 
-   <div class="companies">
+  <div class="companies">
+    {% for company in site.data.companies %}
       <div>
-          <a href="http://www.alodokter.com">
-             <image src="images/logo_alodokter.png">
-          </a>
-          <h3>Alodokter.com</h3>
-          <p>Alodokter.com adalah situs kesehatan No. 1 di Indonesia yang menggunakan Ruby sebagai back-end untuk App dan Web.</p>
+        <a href="{{ company.url }}">
+          <image src="{{ company.image_url }}">
+        </a>
+        <h3>{{ company.name }}</h3>
+        <p>{{ company.description }}</p>
       </div>
-
-      <div>
-         <a href="http://bukalapak.com">
-            <image src="images/logo_bukalapak.png">
-         </a>
-         <h3>Bukalapak</h3>
-         <p>The biggest e-commerce marketplace in Indonesia.</p>
-      </div>
-
-      <div>
-         <a href="https://cookpad.com/id">
-            <image src="images/logo_cookpad.png">
-         </a>
-         <h3>Cookpad Indonesia</h3>
-         <p>Perusahaan teknologi global dengan misi membuat masak sehari-hari jadi menyenangkan.</p>
-      </div>
-
-      <div>
-         <a href="http://cpxi-asia.com/">
-            <image src="images/logo_cpxi.png">
-         </a>
-         <h3>CPXi</h3>
-         <p>CPXi is a growing, global digital media company which includes media executions, content creation, dan engagement strategies.</p>
-      </div>
-
-      <div>
-         <a href="https://www.forstok.com/">
-            <image src="images/logo_forstok.png">
-         </a>
-         <h3>Forstok</h3>
-         <p>FORSTOK is an operating system for multi-channel retail business. It automatically synchronizes inventory, orders, customers and financial data across channels.</p>
-      </div>
-
-      <div>
-         <a href="https://www.go-jek.com">
-            <image src="images/logo_gojek.png">
-         </a>
-         <h3>GO-JEK</h3>
-         <p>GO-JEK adalah sebuah perusahaan teknologi berjiwa sosial yang bertujuan untuk meningkatkan kesejahteraan pekerja di berbagai sektor informal di Indonesia.</p>
-      </div>
-
-      <div>
-         <a href="https://www.hijup.com/">
-            <image src="images/logo_hijup.png">
-         </a>
-         <h3>HIJUP</h3>
-         <p>Modest Fashion Online</p>
-      </div>
-
-      <div>
-         <a href="https://www.jualo.com">
-            <image src="images/logo_jualo.png">
-         </a>
-         <h3>Jualo</h3>
-         <p>Jualo is Indonesia's fastest growing and best-in-class eclassifieds marketplace</p>
-      </div>
-
-      <div>
-         <a href="http://midtrans.com">
-            <image src="images/logo_midtrans.png">
-         </a>
-         <h3>Midtrans</h3>
-         <p>Melengkapi bisnis online di Indonesia dengan sistem pembayaran yang aman &amp; nyaman</p>
-      </div>
-
-      <div>
-         <a href="http://peentar.com">
-            <image src="images/logo_peentar.png">
-         </a>
-         <h3>Peentar</h3>
-         <p>Platform Software-as-a-service untuk enterprise dengan fokus pada perangkat-perangkat IoT</p>
-      </div>
-
-      <div>
-         <a href="https://school.quipper.com/id/">
-            <image src="images/logo_quipper.png">
-         </a>
-         <h3>Quipper</h3>
-         <p>Creating a learning revolution with technology</p>
-      </div>
-
-      <div>
-         <a href="http://www.sejasa.com">
-            <image src="images/logo_sejasa.png">
-         </a>
-         <h3>Sejasa</h3>
-         <p>Sejasa is a service marketplace to find trusted and recommended service providers in Indonesia.</p>
-      </div>
-
-      <div>
-         <a href="https://www.sribulancer.com/">
-            <image src="images/logo_sribulancer.png">
-         </a>
-         <h3>Sribulancer</h3>
-         <p>Sribulancer membantu bisnis dan konsumer untuk mencari freelancer bertalenta di seluru dunia.</p>
-      </div>
-
-      <div>
-         <a href="http://starqle.com">
-            <image src="images/logo_starqle.png">
-         </a>
-         <h3>Starqle</h3>
-         <p>Software consulting company specialized in delivering large scale information systems and applications.</p>
-      </div>
-
-      <div>
-         <a href="http://virkea.com">
-            <image src="images/logo_virkea.png">
-         </a>
-         <h3>Virkea</h3>
-         <p>Enterprise-grade E-Procurement solution provider.</p>
-      </div>
-
-      <div>
-         <a href="https://www.wego.co.id">
-            <image src="images/logo_wego.jpg">
-         </a>
-         <h3>Wego</h3>
-         <p>Wego is a travel search engine. It operates 52 country sites (CcTLD) in over 20 languages and local currencies.</p>
-      </div>
-
-      <div>
-         <a href="https://wgs.co.id/">
-            <image src="images/logo_wgs.png">
-         </a>
-         <h3>WGS</h3>
-         <p>One of the largest IT service company offering programming outsourcing, personalized business and enterprise solutions.</p>
-      </div>
-   </div>
+    {% endfor %}
+  </div>
 </section>


### PR DESCRIPTION
Ideally, we should use Jekyll's YML Data feature when dealing data entries, so it will be more editable and readable. Current site still using HTML for storing company information.

This commit will change this format

    <div>
      <a href="http://www.alodokter.com">
        <image src="images/logo_alodokter.png">
      </a>
      <h3>Alodokter.com</h3>
      <p>Alodokter.com adalah situs kesehatan No. 1 di Indonesia yang menggunakan Ruby sebagai back-end untuk App dan Web.</p>
    </div>

Into this

    - name: Alodokter.com
      url: http://www.alodokter.com
      image_url: images/logo_alodokter.png
      description: Alodokter.com adalah situs kesehatan No. 1 di Indonesia yang menggunakan Ruby sebagai back-end untuk App dan Web.

I have carefully checked that i copied all HTML entries verbatimly. Should you see typo/mispelling, please kindly inform me.

I also updated the README.md on how to add company name.

I have tested this locally and seems like everything works.