### PR TITLE
Move Slack invite URL

### DIFF
--- a/slack/index.html
+++ b/slack/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=https://idruby.typeform.com/to/bdmagR" />
+    <meta http-equiv="refresh" content="0; url="https://id-ruby-slack.herokuapp.com" />
   </head>
   <body>
   </body>


### PR DESCRIPTION
To https://id-ruby-slack.herokuapp.com, since the Typeform URL is broken.