### PR TITLE
Fix font path and favicon

### DIFF
--- a/_layouts/conf.html
+++ b/_layouts/conf.html
@@ -7,9 +7,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{ page.description }}" />
     <meta property="og:image" content="{{ page.open_graph_image }}" />
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
     <link href="{{ "/assets/conf.css" }}?{{site.time | date: '%s%N'}}" rel="stylesheet">
-    <link rel="shortcut icon" href="assets/images/favicon.ico">
+    <link rel="shortcut icon" href="{{ "/assets/conf/favicon.ico" }}">
   </head>
 
   <body>


### PR DESCRIPTION
Font are broken since we are serving using HTTPS protocol. This PR makes it agnostic.
Favicon are broken since it was serving from the wrong path. This PR fixes it.