### PR TITLE
Correcting the link to Slack

### DIFF
--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -3,7 +3,7 @@
         <a href="http://ruby.id" style="margin-left: 0;">ID-Ruby</a>
         |<a href="https://github.com/id-ruby/id-ruby">Github</a>
         |<a href="https://www.meetup.com/jakartarb">Meetup</a>
-        |<a href="http://tinyurl.com/id-ruby-slack">Slack</a>
+        |<a href="https://ruby.id/slack">Slack</a>
         |<a href="https://t.me/ruby_id">Telegram</a>
         <p>Incorporated theme by <a href="https://sendtoinc.com">Inc</a></p>
     </div>


### PR DESCRIPTION
Current link doesn't actually lead to our Slack page, but instead, to a private Typeform page. I think this isn't intended, cmiiw.

![typeform](https://user-images.githubusercontent.com/166730/87712581-d8fa3000-c7e3-11ea-87ef-6f0fda03168c.png)

Current link: http://tinyurl.com/id-ruby-slack
Proposed replacement: https://ruby.id/slack